### PR TITLE
feat: real-time SSE progress + storage dashboard — closes #12, #14

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -3,8 +3,11 @@
 import io
 import json
 import os
+import shutil
+import time
 import xml.etree.ElementTree as ET
-from flask import Blueprint, render_template, request, jsonify, current_app, send_file, abort, session, redirect, url_for
+from flask import Blueprint, render_template, request, jsonify, current_app, send_file, abort, session, redirect, url_for, Response
+from sqlalchemy import func
 from .models import db, Channel, Video, DownloadLog
 from .downloader import VideoDownloader
 from .auth import is_auth_enabled
@@ -833,4 +836,91 @@ def api_channels_import():
         'skipped': skipped,
         'errors': import_errors,
         'message': f'Import complete: {imported} imported, {skipped} skipped, {len(import_errors)} errors',
+    })
+
+
+# ==================== Real-time Events (SSE) ====================
+
+@bp.route('/api/events')
+def api_events():
+    """Server-Sent Events endpoint for real-time download progress.
+
+    Clients connect with EventSource('/api/events') and receive JSON events
+    of the following types:
+      - download_progress  {video_id, title, filename, percent, speed, eta, status}
+      - download_complete  {video_id, title, channel, file_size, file_path}
+      - download_failed    {video_id, title, channel, error}
+      - queue_update       {video_id?, title?, action?, active_count?, cancelled?}
+      - heartbeat          {ts}  (sent every 15 s to keep the connection alive)
+    """
+    from .scheduler import subscribe, unsubscribe
+
+    def generate():
+        client_queue = subscribe()
+        try:
+            # Send an initial heartbeat so the client knows the connection is live
+            yield f"event: heartbeat\ndata: {json.dumps({'ts': time.time()})}\n\n"
+
+            while True:
+                try:
+                    # Block for up to 15 seconds, then send a heartbeat to prevent
+                    # proxy / browser timeouts.
+                    payload = client_queue.get(timeout=15)
+                    data = json.loads(payload)
+                    event_type = data.pop('type', 'message')
+                    yield f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
+                except Exception:
+                    # Timeout — send heartbeat and loop
+                    yield f"event: heartbeat\ndata: {json.dumps({'ts': time.time()})}\n\n"
+        finally:
+            unsubscribe(client_queue)
+
+    response = Response(generate(), mimetype='text/event-stream')
+    response.headers['Cache-Control'] = 'no-cache'
+    response.headers['X-Accel-Buffering'] = 'no'  # Disable nginx buffering
+    return response
+
+
+# ==================== Storage Dashboard ====================
+
+@bp.route('/api/storage', methods=['GET'])
+def api_storage():
+    """Return disk usage and total downloaded file size.
+
+    Response:
+      {
+        "disk_total": <bytes>,
+        "disk_used":  <bytes>,
+        "disk_free":  <bytes>,
+        "disk_used_pct": <0-100 float>,
+        "download_total": <bytes>,   # sum of Video.file_size for completed videos
+        "download_path": <str>
+      }
+    """
+    download_path = current_app.config.get('DOWNLOAD_PATH', '/downloads')
+
+    try:
+        usage = shutil.disk_usage(download_path)
+        disk_total = usage.total
+        disk_used = usage.used
+        disk_free = usage.free
+        disk_used_pct = round(disk_used / disk_total * 100, 1) if disk_total > 0 else 0
+    except OSError:
+        disk_total = disk_used = disk_free = 0
+        disk_used_pct = 0
+
+    # Sum file_size for all completed videos (file_size may be None for some rows)
+    result = db.session.query(func.sum(Video.file_size)).filter(
+        Video.status == 'completed',
+        Video.file_size.isnot(None),
+    ).scalar()
+    download_total = result or 0
+
+    return jsonify({
+        'disk_total': disk_total,
+        'disk_used': disk_used,
+        'disk_free': disk_free,
+        'disk_used_pct': disk_used_pct,
+        'download_total': download_total,
+        'download_path': download_path,
     })

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -1,10 +1,12 @@
 """Background scheduler for channel checking and video downloading."""
 
 import fcntl
+import json
 import logging
+import queue
 from datetime import datetime, timedelta
 from threading import Thread, Event, Lock
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.interval import IntervalTrigger
@@ -16,6 +18,45 @@ from .rumble_extractor import RumbleExtractor
 from .notifications import NotificationManager
 
 logger = logging.getLogger(__name__)
+
+# ==================== Module-Level Event Bus ====================
+# A list of per-client queues.  Each SSE connection appends its own queue
+# here so it receives every event published by scheduler threads.
+
+_subscribers: List[queue.Queue] = []
+_subscribers_lock = Lock()
+
+
+def subscribe() -> queue.Queue:
+    """Register a new SSE client and return its dedicated queue."""
+    q: queue.Queue = queue.Queue(maxsize=100)
+    with _subscribers_lock:
+        _subscribers.append(q)
+    return q
+
+
+def unsubscribe(q: queue.Queue) -> None:
+    """Remove a client queue when the SSE connection closes."""
+    with _subscribers_lock:
+        try:
+            _subscribers.remove(q)
+        except ValueError:
+            pass
+
+
+def publish_event(event_type: str, data: dict) -> None:
+    """Publish an event to all connected SSE clients (non-blocking)."""
+    payload = json.dumps({'type': event_type, **data})
+    with _subscribers_lock:
+        dead: List[queue.Queue] = []
+        for q in _subscribers:
+            try:
+                q.put_nowait(payload)
+            except queue.Full:
+                # Slow / stale client — drop and clean up
+                dead.append(q)
+        for q in dead:
+            _subscribers.remove(q)
 
 
 class DownloadCancelled(Exception):
@@ -471,6 +512,13 @@ class DownloadScheduler:
 
                 logger.info(f'Started concurrent download for video {video.id}: {video.title}')
 
+                # Notify SSE clients that the queue changed
+                publish_event('queue_update', {
+                    'video_id': video.id,
+                    'title': video.title,
+                    'action': 'started',
+                })
+
     def _download_video_thread(self, video_id: int, cancel_event: Event):
         """Thread wrapper for downloading a video with proper app context."""
         try:
@@ -502,7 +550,7 @@ class DownloadScheduler:
         db.session.commit()
 
         def progress_hook(d):
-            """Progress hook that checks for cancellation."""
+            """Progress hook that checks for cancellation and publishes SSE events."""
             # Check for cancellation
             if cancel_event.is_set():
                 raise DownloadCancelled(f"Download cancelled for video {video.id}")
@@ -516,7 +564,7 @@ class DownloadScheduler:
                         percent = (downloaded / total * 100) if total > 0 else 0
                         speed = d.get('speed', 0)
                         eta = d.get('eta', 0)
-                        self._active_downloads[video.id]['progress'] = {
+                        progress = {
                             'status': 'downloading',
                             'percent': round(percent, 1),
                             'downloaded': downloaded,
@@ -524,11 +572,30 @@ class DownloadScheduler:
                             'speed': speed,
                             'eta': eta,
                         }
+                        self._active_downloads[video.id]['progress'] = progress
+
+                        # Publish SSE progress event
+                        publish_event('download_progress', {
+                            'video_id': video.id,
+                            'title': video.title,
+                            'filename': d.get('filename', ''),
+                            **progress,
+                        })
+
                     elif d['status'] == 'finished':
-                        self._active_downloads[video.id]['progress'] = {
+                        progress = {
                             'status': 'processing',
                             'percent': 100,
                         }
+                        self._active_downloads[video.id]['progress'] = progress
+
+                        # Publish SSE progress event for processing phase
+                        publish_event('download_progress', {
+                            'video_id': video.id,
+                            'title': video.title,
+                            'filename': d.get('filename', ''),
+                            **progress,
+                        })
 
         try:
             result = self.downloader.download_video(
@@ -556,6 +623,15 @@ class DownloadScheduler:
                     file_size=result['file_size'],
                     duration=video.duration
                 )
+
+                # Publish SSE completion event
+                publish_event('download_complete', {
+                    'video_id': video.id,
+                    'title': video.title,
+                    'channel': channel.name,
+                    'file_size': result['file_size'],
+                    'file_path': result['file_path'],
+                })
             else:
                 video.status = 'failed'
                 video.error_message = result['error']
@@ -567,7 +643,20 @@ class DownloadScheduler:
                     video.title, channel.name, result['error']
                 )
 
+                # Publish SSE failure event
+                publish_event('download_failed', {
+                    'video_id': video.id,
+                    'title': video.title,
+                    'channel': channel.name,
+                    'error': result['error'],
+                })
+
             db.session.commit()
+
+            # Publish queue update so clients refresh pending counts
+            publish_event('queue_update', {
+                'active_count': len(self._active_downloads) - 1,  # this slot is about to free
+            })
 
         except DownloadCancelled:
             video.status = 'pending'  # Back to pending so it can be retried
@@ -578,6 +667,11 @@ class DownloadScheduler:
                            f'Download cancelled: {video.title}')
             logger.info(f'Download cancelled for video {video.id}')
 
+            publish_event('queue_update', {
+                'video_id': video.id,
+                'cancelled': True,
+            })
+
         except Exception as e:
             video.status = 'failed'
             video.error_message = str(e)
@@ -585,6 +679,12 @@ class DownloadScheduler:
 
             self._log_action(channel.id, video.id, 'error',
                            f'Download exception: {e}')
+
+            publish_event('download_failed', {
+                'video_id': video.id,
+                'title': video.title,
+                'error': str(e),
+            })
 
         finally:
             # Remove from active downloads

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1029,6 +1029,81 @@ input.readonly {
 .filter-group label {
     color: var(--text-secondary);
     font-size: 0.75rem;
+/* SSE connection indicator */
+.sse-indicator {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.sse-connected {
+    background: var(--success);
+    box-shadow: 0 0 4px var(--success);
+}
+
+.sse-connecting {
+    background: var(--warning);
+    animation: pulse 1.2s infinite;
+}
+
+.sse-fallback {
+    background: var(--error);
+}
+
+@keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.3; }
+}
+
+/* Storage Dashboard Card */
+.storage-card {
+    background: var(--bg-card);
+    padding: 1.5rem;
+    border-radius: 8px;
+    margin-bottom: 2rem;
+}
+
+.storage-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+}
+
+.storage-header h2 {
+    margin: 0;
+}
+
+.storage-path {
+    font-family: monospace;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    background: var(--bg-dark);
+    padding: 0.2rem 0.5rem;
+    border-radius: 4px;
+    max-width: 60%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.storage-stats {
+    display: flex;
+    gap: 2rem;
+    margin-bottom: 1rem;
+}
+
+.storage-stat {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+}
+
+.storage-stat-label {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
     text-transform: uppercase;
     letter-spacing: 0.5px;
 }
@@ -1100,6 +1175,91 @@ input.readonly {
 }
 
 /* ── Responsive ── */
+.storage-stat-value {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.storage-bar-wrap {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+}
+
+.storage-bar {
+    flex: 1;
+    height: 12px;
+    background: var(--bg-input);
+    border-radius: 6px;
+    overflow: hidden;
+    position: relative;
+}
+
+/* Overall disk-used fill (sits underneath the downloads layer) */
+.storage-bar-fill {
+    position: absolute;
+    left: 0;
+    top: 0;
+    height: 100%;
+    background: #60a5fa;
+    border-radius: 6px;
+    transition: width 0.4s ease;
+}
+
+.storage-bar-fill.storage-bar-warn {
+    background: var(--warning);
+}
+
+.storage-bar-fill.storage-bar-crit {
+    background: var(--error);
+}
+
+/* Downloads-attributable slice — overlaid on top of the used fill */
+.storage-bar-downloads {
+    position: absolute;
+    left: 0;
+    top: 0;
+    height: 100%;
+    background: var(--accent);
+    border-radius: 6px;
+    transition: width 0.4s ease;
+    opacity: 0.85;
+}
+
+.storage-bar-pct {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    min-width: 45px;
+    text-align: right;
+}
+
+.storage-legend {
+    display: flex;
+    gap: 1.5rem;
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+}
+
+.storage-legend-item {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+.legend-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.legend-dot-used { background: #60a5fa; }
+.legend-dot-downloads { background: var(--accent); }
+.legend-dot-free { background: var(--bg-input); border: 1px solid var(--border); }
+
+/* Responsive */
 @media (max-width: 768px) {
     .navbar {
         flex-direction: column;
@@ -1132,6 +1292,21 @@ input.readonly {
         flex-direction: column;
         gap: 1rem;
         align-items: flex-start;
+    }
+
+    .storage-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.5rem;
+    }
+
+    .storage-path {
+        max-width: 100%;
+    }
+
+    .storage-stats {
+        flex-wrap: wrap;
+        gap: 1rem;
     }
 
     .download-item {

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -1,30 +1,36 @@
 // Video Downloader Frontend JS
 
-// Auto-refresh stats every 30 seconds on dashboard
+// Refresh stat cards by polling /api/stats.
+// On the dashboard, the SSE connection (see index.html) provides real-time
+// download progress.  Stats (video counts) are refreshed here on a slower
+// cadence as a lightweight supplement — SSE completion events also trigger
+// updateQueueStatus() which pulls fresh counts via /api/queue/status.
+async function refreshStatCards() {
+    try {
+        const response = await fetch('/api/stats');
+        const stats = await response.json();
+
+        const cards = document.querySelectorAll('.stat-card');
+        cards.forEach(card => {
+            const label = card.querySelector('.stat-label')?.textContent.toLowerCase();
+            const value = card.querySelector('.stat-value');
+            if (!label || !value) return;
+
+            if (label.includes('pending')) value.textContent = stats.pending_videos;
+            else if (label.includes('downloaded')) value.textContent = stats.completed_videos;
+            else if (label.includes('failed')) value.textContent = stats.failed_videos;
+            else if (label.includes('total channels')) value.textContent = stats.total_channels;
+            else if (label.includes('active')) value.textContent = stats.enabled_channels;
+            else if (label.includes('total videos')) value.textContent = stats.total_videos;
+        });
+    } catch (e) {
+        console.error('Failed to refresh stats:', e);
+    }
+}
+
 if (document.querySelector('.stats-grid')) {
-    setInterval(async () => {
-        try {
-            const response = await fetch('/api/stats');
-            const stats = await response.json();
-
-            // Update stat cards if they exist
-            const cards = document.querySelectorAll('.stat-card');
-            cards.forEach(card => {
-                const label = card.querySelector('.stat-label')?.textContent.toLowerCase();
-                const value = card.querySelector('.stat-value');
-                if (!label || !value) return;
-
-                if (label.includes('pending')) value.textContent = stats.pending_videos;
-                else if (label.includes('downloaded')) value.textContent = stats.completed_videos;
-                else if (label.includes('failed')) value.textContent = stats.failed_videos;
-                else if (label.includes('total channels')) value.textContent = stats.total_channels;
-                else if (label.includes('active')) value.textContent = stats.enabled_channels;
-                else if (label.includes('total videos')) value.textContent = stats.total_videos;
-            });
-        } catch (e) {
-            console.error('Failed to refresh stats:', e);
-        }
-    }, 30000);
+    // Refresh every 60 s (SSE events will trigger more targeted updates faster)
+    setInterval(refreshStatCards, 60000);
 }
 
 // Toast notification helper

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -17,8 +17,47 @@
     <div class="queue-status">
         <span id="queue-status-text">Loading...</span>
         <span id="pending-count"></span>
+        <span id="sse-indicator" class="sse-indicator sse-connecting" title="Real-time connection status"></span>
     </div>
     <div id="active-downloads" class="active-downloads"></div>
+</section>
+
+<!-- Storage Dashboard -->
+<section class="storage-card" id="storage-panel">
+    <div class="storage-header">
+        <h2>Storage</h2>
+        <span id="storage-path" class="storage-path"></span>
+    </div>
+    <div class="storage-stats">
+        <div class="storage-stat">
+            <span class="storage-stat-label">Total</span>
+            <span class="storage-stat-value" id="storage-total">--</span>
+        </div>
+        <div class="storage-stat">
+            <span class="storage-stat-label">Used</span>
+            <span class="storage-stat-value" id="storage-used">--</span>
+        </div>
+        <div class="storage-stat">
+            <span class="storage-stat-label">Free</span>
+            <span class="storage-stat-value" id="storage-free">--</span>
+        </div>
+        <div class="storage-stat">
+            <span class="storage-stat-label">Downloads</span>
+            <span class="storage-stat-value" id="storage-downloads">--</span>
+        </div>
+    </div>
+    <div class="storage-bar-wrap">
+        <div class="storage-bar">
+            <div class="storage-bar-fill" id="storage-bar-fill" style="width: 0%"></div>
+            <div class="storage-bar-downloads" id="storage-bar-downloads" style="width: 0%"></div>
+        </div>
+        <span class="storage-bar-pct" id="storage-bar-pct">0%</span>
+    </div>
+    <div class="storage-legend">
+        <span class="storage-legend-item"><span class="legend-dot legend-dot-used"></span>Disk used</span>
+        <span class="storage-legend-item"><span class="legend-dot legend-dot-downloads"></span>Your downloads</span>
+        <span class="storage-legend-item"><span class="legend-dot legend-dot-free"></span>Free</span>
+    </div>
 </section>
 
 <section class="stats-grid">
@@ -239,9 +278,129 @@ async function checkChannel(id) {
     }
 }
 
-// Queue Control Functions
+// ============================================================
+// Queue Control + Real-time SSE
+// ============================================================
+
 let queuePaused = false;
 
+// --- SSE Connection ---
+let _sseSource = null;
+let _sseFallbackTimer = null;
+const SSE_FALLBACK_INTERVAL = 5000; // ms between poll cycles when SSE is down
+
+function setSseIndicator(state) {
+    // state: 'connected' | 'connecting' | 'fallback'
+    const el = document.getElementById('sse-indicator');
+    if (!el) return;
+    el.className = 'sse-indicator sse-' + state;
+    el.title = state === 'connected'
+        ? 'Live updates active'
+        : state === 'fallback'
+            ? 'Using polling fallback'
+            : 'Connecting...';
+}
+
+function startSse() {
+    if (_sseSource) {
+        _sseSource.close();
+        _sseSource = null;
+    }
+    setSseIndicator('connecting');
+
+    const source = new EventSource('/api/events');
+    _sseSource = source;
+
+    source.addEventListener('heartbeat', () => {
+        setSseIndicator('connected');
+        // SSE is live — clear any polling fallback
+        if (_sseFallbackTimer) {
+            clearInterval(_sseFallbackTimer);
+            _sseFallbackTimer = null;
+        }
+    });
+
+    source.addEventListener('download_progress', e => {
+        const d = JSON.parse(e.data);
+        updateDownloadItem(d);
+    });
+
+    source.addEventListener('download_complete', e => {
+        const d = JSON.parse(e.data);
+        removeDownloadItem(d.video_id);
+        updateQueueStatus(); // full refresh to get updated counts
+        updateStorageDisplay();
+    });
+
+    source.addEventListener('download_failed', e => {
+        const d = JSON.parse(e.data);
+        removeDownloadItem(d.video_id);
+        updateQueueStatus();
+    });
+
+    source.addEventListener('queue_update', () => {
+        updateQueueStatus();
+    });
+
+    source.onerror = () => {
+        setSseIndicator('fallback');
+        source.close();
+        _sseSource = null;
+        // Fall back to polling until SSE recovers
+        if (!_sseFallbackTimer) {
+            updateQueueStatus();
+            _sseFallbackTimer = setInterval(updateQueueStatus, SSE_FALLBACK_INTERVAL);
+        }
+        // Try to reconnect after 10 s
+        setTimeout(startSse, 10000);
+    };
+}
+
+// --- Download item helpers ---
+// Keep a per-video-id progress map so we can update individual items in place
+const _activeItems = {};  // video_id -> { title, percent, speed, eta, status }
+
+function updateDownloadItem(d) {
+    _activeItems[d.video_id] = d;
+    renderActiveDownloads();
+}
+
+function removeDownloadItem(videoId) {
+    delete _activeItems[videoId];
+    renderActiveDownloads();
+}
+
+function renderActiveDownloads() {
+    const container = document.getElementById('active-downloads');
+    const items = Object.values(_activeItems);
+    if (items.length === 0) {
+        container.innerHTML = '<p class="no-downloads">No active downloads</p>';
+        return;
+    }
+    container.innerHTML = items.map(dl => {
+        const percent = dl.percent || 0;
+        const speed = dl.speed ? formatSpeed(dl.speed) : '--';
+        const eta = dl.eta ? formatEta(dl.eta) : '--';
+        const statusLabel = dl.status === 'processing' ? 'Processing...' : `${speed} - ETA: ${eta}`;
+        return `
+            <div class="download-item" id="dl-item-${dl.video_id}">
+                <div class="download-info">
+                    <span class="download-title">${dl.title || 'Video #' + dl.video_id}</span>
+                    <span class="download-stats">${statusLabel}</span>
+                </div>
+                <div class="download-progress">
+                    <div class="progress-bar">
+                        <div class="progress-fill" style="width: ${percent}%"></div>
+                    </div>
+                    <span class="progress-text">${percent.toFixed(1)}%</span>
+                </div>
+                <button class="btn btn-sm btn-danger" onclick="cancelDownload(${dl.video_id})">Cancel</button>
+            </div>
+        `;
+    }).join('');
+}
+
+// --- Full queue status poll (used on load and as SSE fallback) ---
 async function updateQueueStatus() {
     try {
         const response = await fetch('/api/queue/status');
@@ -249,54 +408,80 @@ async function updateQueueStatus() {
 
         queuePaused = data.paused;
 
-        // Update pause button
         const pauseBtn = document.getElementById('pause-btn');
         pauseBtn.textContent = data.paused ? 'Resume' : 'Pause';
         pauseBtn.className = data.paused ? 'btn btn-success' : 'btn btn-warning';
 
-        // Update status text
         const statusText = document.getElementById('queue-status-text');
         if (data.paused) {
-            statusText.innerHTML = '<span class="status-paused">⏸ Queue Paused</span>';
+            statusText.innerHTML = '<span class="status-paused">&#9646;&#9646; Queue Paused</span>';
         } else if (data.active_count > 0) {
-            statusText.innerHTML = '<span class="status-active">▶ Downloading...</span>';
+            statusText.innerHTML = '<span class="status-active">&#9654; Downloading...</span>';
         } else {
-            statusText.innerHTML = '<span class="status-idle">● Idle</span>';
+            statusText.innerHTML = '<span class="status-idle">&#9679; Idle</span>';
         }
 
-        // Update pending count
         document.getElementById('pending-count').textContent = `${data.pending_count} pending`;
 
-        // Update active downloads
-        const container = document.getElementById('active-downloads');
-        if (data.active_downloads.length === 0) {
-            container.innerHTML = '<p class="no-downloads">No active downloads</p>';
-        } else {
-            container.innerHTML = data.active_downloads.map(dl => {
-                const progress = dl.progress || {};
-                const percent = progress.percent || 0;
-                const speed = progress.speed ? formatSpeed(progress.speed) : '--';
-                const eta = progress.eta ? formatEta(progress.eta) : '--';
+        // Merge server state into our local map (preserves SSE-delivered granular progress)
+        const serverIds = new Set(data.active_downloads.map(dl => dl.video_id));
 
-                return `
-                    <div class="download-item">
-                        <div class="download-info">
-                            <span class="download-title">${dl.title || 'Video #' + dl.video_id}</span>
-                            <span class="download-stats">${speed} - ETA: ${eta}</span>
-                        </div>
-                        <div class="download-progress">
-                            <div class="progress-bar">
-                                <div class="progress-fill" style="width: ${percent}%"></div>
-                            </div>
-                            <span class="progress-text">${percent.toFixed(1)}%</span>
-                        </div>
-                        <button class="btn btn-sm btn-danger" onclick="cancelDownload(${dl.video_id})">Cancel</button>
-                    </div>
-                `;
-            }).join('');
+        // Remove items the server no longer considers active
+        for (const id of Object.keys(_activeItems)) {
+            if (!serverIds.has(Number(id))) delete _activeItems[id];
         }
+
+        // Add/update items from server (but don't overwrite richer SSE data)
+        for (const dl of data.active_downloads) {
+            if (!_activeItems[dl.video_id]) {
+                _activeItems[dl.video_id] = {
+                    video_id: dl.video_id,
+                    title: dl.title,
+                    ...(dl.progress || {}),
+                };
+            }
+        }
+
+        renderActiveDownloads();
     } catch (e) {
         console.error('Error updating queue status:', e);
+    }
+}
+
+// --- Storage ---
+function formatBytes(bytes) {
+    if (!bytes || bytes === 0) return '0 B';
+    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(1024));
+    return (bytes / Math.pow(1024, i)).toFixed(1) + ' ' + units[i];
+}
+
+async function updateStorageDisplay() {
+    try {
+        const res = await fetch('/api/storage');
+        const d = await res.json();
+
+        document.getElementById('storage-total').textContent = formatBytes(d.disk_total);
+        document.getElementById('storage-used').textContent = formatBytes(d.disk_used);
+        document.getElementById('storage-free').textContent = formatBytes(d.disk_free);
+        document.getElementById('storage-downloads').textContent = formatBytes(d.download_total);
+        document.getElementById('storage-path').textContent = d.download_path || '';
+
+        const usedPct = d.disk_used_pct || 0;
+        const dlPct = d.disk_total > 0
+            ? Math.min((d.download_total / d.disk_total) * 100, usedPct)
+            : 0;
+
+        document.getElementById('storage-bar-fill').style.width = usedPct + '%';
+        document.getElementById('storage-bar-downloads').style.width = dlPct.toFixed(1) + '%';
+        document.getElementById('storage-bar-pct').textContent = usedPct.toFixed(1) + '%';
+
+        // Color the bar red when nearly full
+        const fill = document.getElementById('storage-bar-fill');
+        fill.classList.toggle('storage-bar-warn', usedPct >= 80);
+        fill.classList.toggle('storage-bar-crit', usedPct >= 95);
+    } catch (e) {
+        console.error('Error updating storage:', e);
     }
 }
 
@@ -345,8 +530,14 @@ async function cancelAllDownloads() {
     }
 }
 
-// Update queue status every 2 seconds
+// Initial load
 updateQueueStatus();
-setInterval(updateQueueStatus, 2000);
+updateStorageDisplay();
+
+// Start SSE (primary real-time channel)
+startSse();
+
+// Refresh storage every 60 s regardless of SSE (file sizes change after completion)
+setInterval(updateStorageDisplay, 60000);
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- **#12**: Server-Sent Events endpoint (`/api/events`) streaming real-time download progress
  - Thread-safe event bus (per-client `Queue` + lock, non-blocking publish)
  - Event types: `download_progress`, `download_complete`, `download_failed`, `queue_update`, `heartbeat`
  - Dashboard replaces 2s polling with `EventSource`, SSE indicator dot (green/amber/red)
  - Graceful fallback: on SSE error, switches to 5s polling, retries SSE after 10s
  - `X-Accel-Buffering: no` header for nginx/SWAG compatibility
- **#14**: Storage dashboard card with disk usage + download totals
  - `/api/storage` endpoint via `shutil.disk_usage()` + SQLAlchemy `func.sum`
  - Stacked progress bar (disk used + downloads overlay)
  - Color thresholds: amber >=80%, red >=95%
  - Auto-refreshes on `download_complete` SSE events

Closes #12, #14

## Test plan
- [ ] Open dashboard — SSE indicator shows green, progress updates appear without page refresh
- [ ] Start a download — verify real-time percent/speed/ETA updates
- [ ] Download completes — verify completion event triggers stat + storage refresh
- [ ] Kill SSE connection (e.g. network tab) — verify fallback to polling, then SSE retry
- [ ] Storage card shows correct disk total/used/free with visual bar
- [ ] Multiple browser tabs — each gets independent SSE stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)